### PR TITLE
Update to Python 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,13 @@
 # Docker container for emulation testing
 # Copyright (C) 2023 Zero ASIC
 
-FROM ubuntu:22.04
+FROM python:3.11
 
 # basic setup, including Python and Node.js installations
 # (Node.js is needed for some GitHub Actions)
 RUN \
 apt update -y && \
-apt install -y curl unzip git libsystemc libsystemc-dev \
-    python3 python3-dev python3-pip && \
+apt install -y curl unzip git libsystemc libsystemc-dev && \
 python3 -m pip install --upgrade pip && \
 curl -fsSL https://deb.nodesource.com/setup_19.x | bash - && \
 apt install -y nodejs && \


### PR DESCRIPTION
This PR updates sbtest to use Python 3.11, since we are standardizing on that version for the product launch.  I built a prerelease of this version (`0.0.9-1`) and verified that it works without modifications for griddle and switchboard CI:
* https://github.com/zeroasiccorp/switchboard/pull/97
* https://github.com/zeroasiccorp/griddle/pull/163

The main difference is that we are now using the python base image instead of ubuntu.  However, since the python image is based on debian, which ubuntu is based on, no changes were required in existing CI tests for griddle and switchboard.

Once this PR is merged, I will release this update with the tag `0.0.9`.