### PR TITLE
updated verilator to v5.018

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ apt install -y libfl-dev && \
 git clone https://github.com/verilator/verilator && \
 cd verilator && \
 git pull && \
-git checkout v5.012 && \
+git checkout v5.018 && \
 autoconf && \
 ./configure && \
 make -j `nproc` && \


### PR DESCRIPTION
This PR bumps the verilator version from `v5.012` to `v5.018`. There is a draft PR for switchboard to update to `v5.018` that depends on a new `sbtest` tag to complete.